### PR TITLE
chore: add AI-ready docs, rules, and skills

### DIFF
--- a/.agentready-config.yaml
+++ b/.agentready-config.yaml
@@ -1,0 +1,8 @@
+excluded_attributes:
+ - openapi_specs
+ - container_setup
+ - dbt_project_config
+ - dbt_model_documentation
+ - dbt_data_tests
+ - dbt_project_structure
+ - repomix_config

--- a/.agents/rules/backend.md
+++ b/.agents/rules/backend.md
@@ -1,0 +1,9 @@
+## Scope
+
+Applies to `packages/backend/**`.
+
+## Rules
+
+- Keep Podman Desktop API integration in backend package only.
+- Align backend method signatures with `packages/shared` contracts.
+- Avoid UI-specific logic in backend files.

--- a/.agents/rules/frontend.md
+++ b/.agents/rules/frontend.md
@@ -1,0 +1,9 @@
+## Scope
+
+Applies to `packages/frontend/**`.
+
+## Rules
+
+- Use Svelte 5 runes (`$state`, `$derived`, `$effect`) for reactive state.
+- Keep frontend logic presentation-focused and call backend through API client.
+- Prefer small components and colocated tests.

--- a/.agents/rules/shared.md
+++ b/.agents/rules/shared.md
@@ -1,0 +1,9 @@
+## Scope
+
+Applies to `packages/shared/**`.
+
+## Rules
+
+- Treat shared package as the source of truth for frontend/backend contracts.
+- Any backend API change must be reflected in shared interfaces.
+- Keep shared code runtime-agnostic and dependency-light.

--- a/.agents/skills/extension-development/SKILL.md
+++ b/.agents/skills/extension-development/SKILL.md
@@ -1,0 +1,23 @@
+# Extension Development
+
+Use this guide for end-to-end feature work across backend/frontend/shared.
+
+## Workflow
+
+1. Define or update the contract in `packages/shared`.
+2. Implement backend behavior in `packages/backend`.
+3. Integrate UI in `packages/frontend`.
+4. Validate with lint, typecheck, and tests.
+
+## Typical touchpoints
+
+- Shared API: `packages/shared/src/HelloWorldApi.ts`
+- Backend impl: `packages/backend/src/api-impl.ts`
+- Frontend client: `packages/frontend/src/api/client.ts`
+
+## Validation
+
+```sh
+npm run typecheck
+npm run test
+```

--- a/.agents/skills/svelte-ui-design/SKILL.md
+++ b/.agents/skills/svelte-ui-design/SKILL.md
@@ -1,0 +1,16 @@
+# Svelte UI Design
+
+Use this guide when modifying `packages/frontend`.
+
+## Expectations
+
+- Use Svelte 5 rune APIs for component state.
+- Keep RPC/API calls in dedicated client helpers.
+- Use `@testing-library/svelte` for behavioral component tests.
+
+## Validation
+
+```sh
+npm run svelte:check
+npm run test:frontend
+```

--- a/.agents/skills/unit-testing/SKILL.md
+++ b/.agents/skills/unit-testing/SKILL.md
@@ -1,0 +1,17 @@
+# Unit Testing
+
+Use this guide when adding tests to backend, frontend, or shared packages.
+
+## Scope
+
+- Backend: API behavior, command handlers, integration seams.
+- Frontend: component behavior and state transitions.
+- Shared: contract/message serialization and helper utilities.
+
+## Commands
+
+```sh
+npm run test:backend
+npm run test:frontend
+npm run test:shared
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+ "hooks": {
+  "PostToolUse": [
+   {
+    "matcher": "Edit|Write",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "npx prettier --write \"$CLAUDE_FILE_PATH\" 2>/dev/null; npx eslint --fix \"$CLAUDE_FILE_PATH\" 2>/dev/null || true; exit 0"
+     }
+    ]
+   }
+  ],
+  "PreToolUse": [
+   {
+    "matcher": "Bash",
+    "hooks": [
+     {
+      "type": "command",
+      "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(rm -rf|git push --force|git reset --hard|git checkout \\.)' && echo 'BLOCK: Destructive operation detected. Please confirm with the user first.' && exit 1 || exit 0"
+     }
+    ]
+   }
+  ]
+ }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 **/coverage
 .idea
 output
+.agentready

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+## Project Overview
+
+Full Podman Desktop extension template with separate backend, frontend, and
+shared packages. This template demonstrates a production-style setup for RPC
+communication between a Svelte webview and extension backend.
+
+- **Tech stack**: TypeScript, Svelte 5, Tailwind CSS, npm workspaces
+- **Packages**: `packages/backend`, `packages/frontend`, `packages/shared`
+- **Extension API**: `@podman-desktop/api`
+
+## Quick Start
+
+```sh
+npm install
+npm run build
+```
+
+## Essential Commands
+
+```sh
+npm run build          # build frontend + backend
+npm run watch          # watch frontend + backend
+npm run lint:check
+npm run lint:fix
+npm run format:check
+npm run format:fix
+npm run typecheck
+npm run test
+```
+
+## Single-File Verification
+
+```sh
+npx eslint path/to/file.ts
+npx tsc --noEmit -p packages/backend/tsconfig.json
+npx tsc --noEmit -p packages/frontend/tsconfig.json
+npx tsc --noEmit -p packages/shared/tsconfig.json
+npm run test:backend
+npm run test:frontend
+npm run test:shared
+```
+
+## Skills
+
+Task-specific guidance lives in `.agents/skills/`:
+
+- `extension-development` - backend/frontend/shared change flow
+- `svelte-ui-design` - Svelte 5 component and state guidance
+- `unit-testing` - backend/frontend/shared test strategy
+
+## Architecture
+
+Webview (frontend) <-> shared contract <-> backend extension
+
+- `packages/backend`: extension activation and Podman Desktop API integrations.
+- `packages/frontend`: Svelte webview UI.
+- `packages/shared`: shared interfaces and RPC/message contracts.
+
+## Pattern References
+
+- New backend API method: update `packages/shared/src/HelloWorldApi.ts` and `packages/backend/src/api-impl.ts`
+- New frontend integration: update `packages/frontend/src/api/client.ts` and consuming Svelte component
+- New shared model/message: place in `packages/shared/src`


### PR DESCRIPTION
## What does this PR do?

Adds baseline AI-readiness scaffolding to the full template to improve agent-assisted development out of the box:

- Add `AGENTS.md` tailored to backend/frontend/shared workspace structure
- Add `.agentready-config.yaml` exclusions
- Add `.claude/settings.json` with safe shell guard + post-edit formatting/lint hook
- Add package-scoped `.agents/rules/` files (`backend`, `frontend`, `shared`)
- Add starter `.agents/skills/` docs for extension development, Svelte UI design, and unit testing
- Update `.gitignore` to ignore `.agentready`

## What issues does this PR fix or reference?

Refs podman-desktop/podman-desktop#17640

## How to test this PR?

1. Clone this branch and verify the new AI-readiness files are present.
2. Confirm package-scoped rules match full-template layout (`packages/backend`, `packages/frontend`, `packages/shared`).
3. Confirm `.agentready` is ignored via `.gitignore`.


Made with [Cursor](https://cursor.com)